### PR TITLE
DE-1379: Fix early 500 error

### DIFF
--- a/amp-app-shell.php
+++ b/amp-app-shell.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/xwp/amp-app-shell/
  * Author: AMP Project Contributors, XWP
  * Author URI: https://github.com/xwp/amp-app-shell/graphs/contributors
- * Version: 0.1.6
+ * Version: 0.1.7
  * Text Domain: amp-app-shell
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -17,7 +17,7 @@
 
 define( 'AMP_APP_SHELL__FILE__', __FILE__ );
 define( 'AMP_APP_SHELL__DIR__', dirname( __FILE__ ) );
-define( 'AMP_APP_SHELL__VERSION', '0.1.6' );
+define( 'AMP_APP_SHELL__VERSION', '0.1.7' );
 
 /**
  * Errors encountered while loading the plugin.

--- a/includes/class-amp-app-shell.php
+++ b/includes/class-amp-app-shell.php
@@ -260,10 +260,13 @@ class AMP_App_Shell {
 		$dom             = Document::fromHtml( $response );
 		$content_element = $dom->getElementById( self::CONTENT_ELEMENT_ID );
 
-		if ( ! $content_element ) {
-			status_header( 500 );
-			return esc_html__( 'Unable to locate CONTENT_ELEMENT_ID.', 'amp-app-shell' );
-		}
+		// This code returns too early and doesn't allow a redirect to take place
+		// TODO: Find out if we can detect if a redirect can happen and conditionally run
+		// TODO: Or move this to later in the process
+		// if ( ! $content_element ) {
+		// 	status_header( 500 );
+		// 	return esc_html__( 'Unable to locate CONTENT_ELEMENT_ID.', 'amp-app-shell' );
+		// }
 
 		if ( $is_late ) {
 			self::sanitize_styles_for_shadow_dom( $dom );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amp-app-shell",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Support for app shell navigation via AMP Shadow DOM.",
   "scripts": {
     "build": "npm-run-all build:*",


### PR DESCRIPTION
- [x] Fix 500 error from occurring before the page has time to redirect

If a trailing slash is left off the end of a URL normal Wordpress functionality would try to redirect if a page exists.
The app shell plugin was stopping that from happening by returning a 500 error before WP had a chance to perform the redirect. This change removes that functionality, however it should be reviewed and added back at an appropriate place in the class.

Reference issue:
https://novaent.atlassian.net/browse/DE-1739